### PR TITLE
Adds AbortSignal serialization handler

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,10 @@
     "./handlers/streams.js": {
       "types": "./handlers/streams.d.ts",
       "default": "./handlers/streams.js"
+    },
+    "./handlers/abort-signal.js": {
+      "types": "./handlers/abort-signal.d.ts",
+      "default": "./handlers/abort-signal.js"
     }
   },
   "files": [

--- a/packages/core/src/handlers/abort-signal.ts
+++ b/packages/core/src/handlers/abort-signal.ts
@@ -1,0 +1,231 @@
+/**
+ * @fileoverview AbortSignal handler for cancellation across connection boundaries.
+ *
+ * Teaches Supertalk how to serialize AbortSignal across the wire. Since
+ * AbortSignal is an event target (non-cloneable), the handler creates a proxy
+ * relationship: the sender's signal gets an ID, and the receiver gets a fresh
+ * AbortController's signal keyed by that ID.
+ *
+ * The handler uses two message types:
+ * - `abort`: Real cancellation — the sender's signal was aborted
+ * - `release`: Cleanup — the sender is done with the signal (e.g., call completed)
+ *
+ * Convention: `controller.abort('completed')` on the sender side triggers a
+ * `release` message instead of `abort`. This lets the receiver distinguish
+ * between "the work was cancelled" and "the work finished, clean up the signal."
+ *
+ * @example
+ * ```ts
+ * import {expose, wrap} from '@supertalk/core';
+ * import {AbortSignalHandler} from '@supertalk/core/handlers/abort-signal.js';
+ *
+ * // Both sides need compatible handlers
+ * const options = {handlers: [new AbortSignalHandler()]};
+ *
+ * expose(service, endpoint, options);
+ * const remote = await wrap<Service>(endpoint, options);
+ *
+ * // Caller side
+ * const controller = new AbortController();
+ * const result = remote.search('query', controller.signal);
+ * // Cancel:
+ * controller.abort();
+ * // Or signal completion (cleanup only):
+ * controller.abort('completed');
+ * ```
+ */
+
+import {WIRE_TYPE} from '../lib/constants.js';
+import type {
+  Handler,
+  HandlerConnectionContext,
+  ToWireContext,
+} from '../lib/types.js';
+
+const ABORT_SIGNAL_WIRE_TYPE = 'abort-signal';
+
+/**
+ * Reason value that signals completion rather than cancellation.
+ * When `controller.abort('completed')` is called, the handler sends a
+ * `release` message instead of `abort`.
+ */
+export const COMPLETED = 'completed';
+
+/**
+ * Reason value used when the connection is disconnected.
+ */
+const DISCONNECTED = 'disconnected';
+
+interface WireAbortSignal {
+  [WIRE_TYPE]: typeof ABORT_SIGNAL_WIRE_TYPE;
+  id: number;
+  aborted: boolean;
+  reason?: unknown;
+}
+
+interface AbortMessage {
+  type: 'abort';
+  id: number;
+  reason?: unknown;
+}
+
+interface ReleaseMessage {
+  type: 'release';
+  id: number;
+}
+
+type HandlerPayload = AbortMessage | ReleaseMessage;
+
+/**
+ * Handler for AbortSignal serialization across connection boundaries.
+ *
+ * Create one instance per side and include in the `handlers` array for both
+ * `expose()` and `wrap()`.
+ */
+export class AbortSignalHandler implements Handler<
+  AbortSignal,
+  WireAbortSignal
+> {
+  readonly wireType = ABORT_SIGNAL_WIRE_TYPE;
+
+  #ctx: HandlerConnectionContext | undefined;
+
+  // Sender side: signals we've sent, keyed by ID
+  #nextId = 1;
+  #signalToId = new WeakMap<AbortSignal, number>();
+  #sentSignals = new Map<number, AbortSignal>();
+  #abortListeners = new Map<number, () => void>();
+
+  // Receiver side: AbortControllers we've created, keyed by ID
+  #receivedControllers = new Map<number, AbortController>();
+
+  canHandle(value: unknown): value is AbortSignal {
+    return value instanceof AbortSignal;
+  }
+
+  toWire(signal: AbortSignal, _ctx: ToWireContext): WireAbortSignal {
+    // If already aborted, send the aborted state directly — no need to track
+    if (signal.aborted) {
+      return {
+        [WIRE_TYPE]: ABORT_SIGNAL_WIRE_TYPE,
+        id: 0, // No tracking needed
+        aborted: true,
+        reason: signal.reason,
+      };
+    }
+
+    // Check if we've already sent this signal
+    let id = this.#signalToId.get(signal);
+    if (id !== undefined) {
+      return {
+        [WIRE_TYPE]: ABORT_SIGNAL_WIRE_TYPE,
+        id,
+        aborted: false,
+      };
+    }
+
+    // New signal — assign an ID and start listening
+    id = this.#nextId++;
+    this.#signalToId.set(signal, id);
+    this.#sentSignals.set(id, signal);
+
+    const listener = () => {
+      if (signal.reason === COMPLETED) {
+        this.#ctx?.sendMessage({type: 'release', id} satisfies ReleaseMessage);
+      } else {
+        this.#ctx?.sendMessage({
+          type: 'abort',
+          id,
+          reason: signal.reason,
+        } satisfies AbortMessage);
+      }
+      this.#cleanupSent(id);
+    };
+
+    signal.addEventListener('abort', listener, {once: true});
+    this.#abortListeners.set(id, listener);
+
+    return {
+      [WIRE_TYPE]: ABORT_SIGNAL_WIRE_TYPE,
+      id,
+      aborted: false,
+    };
+  }
+
+  fromWire(wire: WireAbortSignal): AbortSignal {
+    // Already-aborted signal — return a pre-aborted signal
+    if (wire.aborted) {
+      return AbortSignal.abort(wire.reason);
+    }
+
+    // Reuse existing controller if the same signal was sent before
+    const existing = this.#receivedControllers.get(wire.id);
+    if (existing !== undefined) {
+      return existing.signal;
+    }
+
+    // Create a new controller for this ID
+    const controller = new AbortController();
+    this.#receivedControllers.set(wire.id, controller);
+    return controller.signal;
+  }
+
+  connect(ctx: HandlerConnectionContext): void {
+    this.#ctx = ctx;
+  }
+
+  onMessage(payload: unknown): void {
+    const msg = payload as HandlerPayload;
+    if (msg.type === 'abort') {
+      this.#receivedControllers.get(msg.id)?.abort(msg.reason);
+      this.#receivedControllers.delete(msg.id);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    } else if (msg.type === 'release') {
+      this.#receivedControllers.delete(msg.id);
+    }
+  }
+
+  disconnect(): void {
+    this.#ctx = undefined;
+
+    // Abort all received controllers with 'disconnected' reason
+    for (const controller of this.#receivedControllers.values()) {
+      controller.abort(DISCONNECTED);
+    }
+    this.#receivedControllers.clear();
+
+    // Remove all abort listeners from sent signals
+    for (const [id, listener] of this.#abortListeners) {
+      const signal = this.#sentSignals.get(id);
+      signal?.removeEventListener('abort', listener);
+    }
+    this.#abortListeners.clear();
+    this.#sentSignals.clear();
+    // Reset WeakMap and ID counter so reuse after reconnect doesn't
+    // find stale IDs that skip listener registration.
+    this.#signalToId = new WeakMap();
+    this.#nextId = 1;
+  }
+
+  #cleanupSent(id: number): void {
+    this.#abortListeners.delete(id);
+    this.#sentSignals.delete(id);
+    // WeakMap entry will be GC'd automatically
+  }
+
+  /**
+   * Get the number of sent signals being tracked (for testing).
+   * @internal
+   */
+  get _sentCount(): number {
+    return this.#sentSignals.size;
+  }
+
+  /**
+   * Get the number of received controllers being tracked (for testing).
+   * @internal
+   */
+  get _receivedCount(): number {
+    return this.#receivedControllers.size;
+  }
+}

--- a/packages/core/src/test/node/abort_signal_test.ts
+++ b/packages/core/src/test/node/abort_signal_test.ts
@@ -1,0 +1,328 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+/**
+ * Tests for the AbortSignal handler.
+ */
+
+import {suite, test} from 'node:test';
+import * as assert from 'node:assert';
+import {MessageChannel} from 'node:worker_threads';
+import {setupService} from './test-utils.js';
+import {expose, wrap} from '../../index.js';
+import {AbortSignalHandler, COMPLETED} from '../../handlers/abort-signal.js';
+
+function waitForMessages(ms = 20): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+void suite('AbortSignal handler', () => {
+  void test('passes an AbortSignal as an argument', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    await using ctx = await setupService(
+      {
+        doWork(_data: string, signal: AbortSignal) {
+          receivedSignal = signal;
+          return 'done';
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    const result = await ctx.remote.doWork('test', controller.signal);
+    assert.strictEqual(result, 'done');
+    assert.ok(receivedSignal instanceof AbortSignal);
+    assert.strictEqual(receivedSignal?.aborted, false);
+  });
+
+  void test('abort propagates to the receiver side', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    let abortPromiseResolve: () => void;
+    const abortPromise = new Promise<void>((r) => {
+      abortPromiseResolve = r;
+    });
+
+    await using ctx = await setupService(
+      {
+        async longTask(signal: AbortSignal) {
+          receivedSignal = signal;
+          // Wait until the signal is aborted
+          if (!signal.aborted) {
+            await new Promise<void>((resolve) => {
+              signal.addEventListener('abort', () => resolve(), {once: true});
+            });
+          }
+          abortPromiseResolve();
+          return 'cancelled';
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    // Start the long task (don't await — it blocks until abort)
+    const resultPromise = ctx.remote.longTask(controller.signal);
+
+    // Give time for the call to reach the other side
+    await waitForMessages();
+
+    // Abort
+    controller.abort();
+
+    // Wait for the abort to propagate
+    await abortPromise;
+
+    assert.ok(receivedSignal !== undefined);
+    assert.strictEqual(receivedSignal?.aborted, true);
+
+    // The method should still return
+    const result = await resultPromise;
+    assert.strictEqual(result, 'cancelled');
+  });
+
+  void test('abort reason propagates to the receiver side', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    await using ctx = await setupService(
+      {
+        async waitForAbort(signal: AbortSignal) {
+          receivedSignal = signal;
+          if (!signal.aborted) {
+            await new Promise<void>((resolve) => {
+              signal.addEventListener('abort', () => resolve(), {once: true});
+            });
+          }
+          return signal.reason;
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    const resultPromise = ctx.remote.waitForAbort(controller.signal);
+    await waitForMessages();
+
+    const reason = new Error('user cancelled');
+    controller.abort(reason);
+
+    const result = await resultPromise;
+    // The reason is serialized through structured clone, so it comes back as
+    // a plain object with message/name/stack — but the Error name is preserved
+    assert.ok(receivedSignal !== undefined);
+    assert.strictEqual(receivedSignal?.aborted, true);
+    // The result will be the serialized reason
+    assert.ok(result !== undefined);
+  });
+
+  void test('already-aborted signal is received as aborted', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    await using ctx = await setupService(
+      {
+        checkSignal(signal: AbortSignal) {
+          receivedSignal = signal;
+          return signal.aborted;
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    controller.abort('pre-aborted');
+
+    const result = await ctx.remote.checkSignal(controller.signal);
+    assert.strictEqual(result, true);
+    assert.ok(receivedSignal !== undefined);
+    assert.strictEqual(receivedSignal?.aborted, true);
+    assert.strictEqual(receivedSignal?.reason, 'pre-aborted');
+  });
+
+  void test('completed convention sends release instead of abort', async () => {
+    const senderHandler = new AbortSignalHandler();
+    const receiverHandler = new AbortSignalHandler();
+    let receivedSignal: AbortSignal | undefined;
+
+    const {port1, port2} = new MessageChannel();
+
+    expose(
+      {
+        async waitForSignal(signal: AbortSignal) {
+          receivedSignal = signal;
+          // Wait a bit for potential abort/release messages
+          await waitForMessages(50);
+          return signal.aborted;
+        },
+      },
+      port1,
+      {handlers: [senderHandler]},
+    );
+    const remote = await wrap<{
+      waitForSignal(signal: AbortSignal): Promise<boolean>;
+    }>(port2, {handlers: [receiverHandler]});
+
+    const controller = new AbortController();
+    const resultPromise = remote.waitForSignal(controller.signal);
+    await waitForMessages();
+
+    // Signal completion, not cancellation
+    controller.abort(COMPLETED);
+    await waitForMessages();
+
+    const result = await resultPromise;
+    // The receiver's signal should NOT be aborted — release is cleanup only
+    assert.strictEqual(result, false);
+    assert.ok(receivedSignal !== undefined);
+    assert.strictEqual(receivedSignal?.aborted, false);
+
+    // Cleanup
+    assert.strictEqual(receiverHandler._receivedCount, 0);
+    assert.strictEqual(senderHandler._sentCount, 0);
+
+    port1.close();
+    port2.close();
+  });
+
+  void test('disconnect aborts all received signals', async () => {
+    // exposeHandler is on the expose (port1) side — it receives AbortSignals
+    // wrapHandler is on the wrap (port2) side — it sends AbortSignals
+    const exposeHandler = new AbortSignalHandler();
+    const wrapHandler = new AbortSignalHandler();
+    let receivedSignal: AbortSignal | undefined;
+
+    const {port1, port2} = new MessageChannel();
+
+    // expose() returns a cleanup function that calls connection.close()
+    const cleanup = expose(
+      {
+        hold(signal: AbortSignal) {
+          receivedSignal = signal;
+          return 'held';
+        },
+      },
+      port1,
+      {handlers: [exposeHandler]},
+    );
+    const remote = await wrap<{hold(signal: AbortSignal): string}>(port2, {
+      handlers: [wrapHandler],
+    });
+
+    const controller = new AbortController();
+    await remote.hold(controller.signal);
+    assert.ok(receivedSignal !== undefined);
+    assert.strictEqual(receivedSignal?.aborted, false);
+    // The expose side received the signal via fromWire()
+    assert.strictEqual(exposeHandler._receivedCount, 1);
+
+    // Close the connection — calls disconnect() on the expose handler,
+    // which should abort all pending received signals
+    cleanup();
+
+    assert.strictEqual(receivedSignal?.aborted, true);
+    assert.strictEqual(receivedSignal?.reason, 'disconnected');
+    assert.strictEqual(exposeHandler._receivedCount, 0);
+
+    port1.close();
+    port2.close();
+  });
+
+  void test('multiple signals can be tracked independently', async () => {
+    const signals: Array<AbortSignal> = [];
+
+    await using ctx = await setupService(
+      {
+        register(signal: AbortSignal) {
+          signals.push(signal);
+          return signals.length;
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const c1 = new AbortController();
+    const c2 = new AbortController();
+    const c3 = new AbortController();
+
+    await ctx.remote.register(c1.signal);
+    await ctx.remote.register(c2.signal);
+    await ctx.remote.register(c3.signal);
+
+    assert.strictEqual(signals.length, 3);
+
+    // Abort only the second one
+    c2.abort('cancelled-2');
+    await waitForMessages();
+
+    assert.strictEqual(signals[0]?.aborted, false);
+    assert.strictEqual(signals[1]?.aborted, true);
+    assert.strictEqual(signals[1]?.reason, 'cancelled-2');
+    assert.strictEqual(signals[2]?.aborted, false);
+
+    // Abort the first
+    c1.abort();
+    await waitForMessages();
+
+    assert.strictEqual(signals[0]?.aborted, true);
+    assert.strictEqual(signals[2]?.aborted, false);
+  });
+
+  void test('same signal sent twice uses same ID', async () => {
+    const signals: Array<AbortSignal> = [];
+
+    await using ctx = await setupService(
+      {
+        register(signal: AbortSignal) {
+          signals.push(signal);
+          return signals.length;
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    await ctx.remote.register(controller.signal);
+    await ctx.remote.register(controller.signal);
+
+    assert.strictEqual(signals.length, 2);
+
+    // Both signals on the receiver side should abort when the single controller aborts
+    controller.abort('shared');
+    await waitForMessages();
+
+    assert.strictEqual(signals[0]?.aborted, true);
+    assert.strictEqual(signals[1]?.aborted, true);
+  });
+
+  void test('signal used with throwIfAborted pattern', async () => {
+    await using ctx = await setupService(
+      {
+        async processItems(items: Array<string>, signal: AbortSignal) {
+          const processed: Array<string> = [];
+          for (const item of items) {
+            signal.throwIfAborted();
+            processed.push(item.toUpperCase());
+            // Simulate async work
+            await new Promise((r) => setTimeout(r, 5));
+          }
+          return processed;
+        },
+      },
+      {handlers: [new AbortSignalHandler()]},
+    );
+
+    const controller = new AbortController();
+    // Abort after a short delay
+    setTimeout(() => controller.abort(), 15);
+
+    try {
+      await ctx.remote.processItems(
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+        controller.signal,
+      );
+      // Might complete if fast enough, that's OK
+    } catch {
+      // Expected — the method threw via throwIfAborted()
+    }
+  });
+});


### PR DESCRIPTION
 - Enables cancellation and signal tracking across connection boundaries
 - Distinguishes between explicit cancellation and completion-driven cleanup
 - Automatically handles resource lifecycle by cleaning up listeners and controllers on disconnection
 - Provides a mechanism to map remote signals to local controllers using unique identifiers